### PR TITLE
Add security checks and documentation for ECgFp5 operations

### DIFF
--- a/curve/ecgfp5/scalar_field.go
+++ b/curve/ecgfp5/scalar_field.go
@@ -50,6 +50,11 @@ func ScalarElementFromLittleEndianBytes(data []byte) ECgFp5Scalar {
 	for i := 0; i < 5; i++ {
 		value[i] = binary.LittleEndian.Uint64(data[i*8:])
 	}
+
+	if !value.IsCanonical() {
+		panic("trying to deserialize non-canonical bytes")
+	}
+
 	return value
 }
 

--- a/curve/ecgfp5/scalar_field.go
+++ b/curve/ecgfp5/scalar_field.go
@@ -9,7 +9,10 @@ import (
 	. "github.com/elliottech/poseidon_crypto/int"
 )
 
-// ECgFp5Scalar represents the scalar field of the ECgFP5 elliptic curve where
+// ECgFp5Scalar represents the scalar field of the ECgFP5 elliptic curve.
+//
+// GROUP ORDER (PRIME):
+// The group order is a PRIME number p ≈ 2^319:
 // p = 1067993516717146951041484916571792702745057740581727230159139685185762082554198619328292418486241
 type ECgFp5Scalar [5]uint64
 
@@ -18,6 +21,7 @@ func (s ECgFp5Scalar) IsCanonical() bool {
 }
 
 var (
+	// ORDER is the prime order of the ECgFp5 group (p ≈ 2^319).
 	ORDER, _ = new(big.Int).SetString("1067993516717146951041484916571792702745057740581727230159139685185762082554198619328292418486241", 10)
 	ZERO     = ECgFp5Scalar{}
 	ONE      = ECgFp5Scalar{1, 0, 0, 0, 0}
@@ -165,8 +169,16 @@ func (s *ECgFp5Scalar) Sub(rhs ECgFp5Scalar) ECgFp5Scalar {
 	return Select(c, r0, r1)
 }
 
-// 's' must be less than n.
+// 's' and 'rhs' must be less than n (canonical form).
 func (s ECgFp5Scalar) Mul(rhs ECgFp5Scalar) ECgFp5Scalar {
+	// SECURITY: Verify both operands are canonical before Montgomery multiplication
+	if !s.IsCanonical() {
+		panic("Mul: first operand 's' must be canonical (< n)")
+	}
+	if !rhs.IsCanonical() {
+		panic("Mul: second operand 'rhs' must be canonical (< n)")
+	}
+
 	res := s.MontyMul(R2).MontyMul(rhs)
 	return res
 }
@@ -175,6 +187,11 @@ func (s ECgFp5Scalar) Mul(rhs ECgFp5Scalar) ECgFp5Scalar {
 // Returns (s*rhs)/2^320 mod n.
 // 's' MUST be less than n (the other operand can be up to 2^320-1).
 func (s ECgFp5Scalar) MontyMul(rhs ECgFp5Scalar) ECgFp5Scalar {
+	// SECURITY: Verify that 's' is canonical (< n) as required by Montgomery multiplication
+	if !s.IsCanonical() {
+		panic("MontyMul: first operand 's' must be canonical (< n)")
+	}
+
 	var r ECgFp5Scalar
 	for i := 0; i < 5; i++ {
 		// Iteration i computes r <- (r + self*rhs_i + f*n)/2^64.

--- a/signature/schnorr/schnorr.go
+++ b/signature/schnorr/schnorr.go
@@ -80,6 +80,8 @@ func SigFromBytes(b []byte) (Signature, error) {
 		return ZERO_SIG, errors.New("invalid signature length, must be 80 bytes")
 	}
 
+	// ScalarElementFromLittleEndianBytes will check s and e are both in
+	// canonical form
 	return Signature{
 		S: curve.ScalarElementFromLittleEndianBytes(b[:40]),
 		E: curve.ScalarElementFromLittleEndianBytes(b[40:]),

--- a/signature/schnorr/schnorr.go
+++ b/signature/schnorr/schnorr.go
@@ -101,6 +101,8 @@ func SchnorrSignHashedMessage(hashedMsg gFp5.Element, sk curve.ECgFp5Scalar) Sig
 	copy(preImage[:5], r[:])
 	copy(preImage[5:], hashedMsg[:])
 
+	// TODO: Something to be considered later (and require coordinate with Rust)
+	//
 	// It is possible that we only use 128 bits for e (instread of 320 bits)
 	// That is, we can build e with the first 3 limbs of p2.HashToQuinticExtension(preImage)
 	// This should improve the performance of schnorr signature.
@@ -126,6 +128,8 @@ func SchnorrSignHashedMessage2(hashedMsg gFp5.Element, sk, k curve.ECgFp5Scalar)
 	copy(preImage[:5], r[:])
 	copy(preImage[5:], hashedMsg[:])
 
+	// TODO: Something to be considered later (and require coordinate with Rust)
+	//
 	// It is possible that we only use 128 bits for e (instread of 320 bits)
 	// That is, we can build e with the first 3 limbs of p2.HashToQuinticExtension(preImage)
 	// This should improve the performance of schnorr signature.

--- a/signature/schnorr/schnorr.go
+++ b/signature/schnorr/schnorr.go
@@ -1,3 +1,42 @@
+// Package signature implements Schnorr signatures over the ECgFp5 elliptic curve.
+//
+// CURVE SECURITY PROPERTIES:
+//
+// ECgFp5 is an elliptic curve with PRIME ORDER (no cofactor), which provides:
+// - No small subgroup attacks possible
+// - No cofactor clearing needed
+// - Canonical point encoding (prevents malleability)
+// - All decoded points are valid group elements
+//
+// SIGNATURE SCHEME:
+//
+// This implementation uses:
+// - Poseidon2 hash function for challenge generation
+// - Pre-hashed messages (caller must hash messages to Fp5 elements)
+// - Standard Schnorr signature equation: s = k - e·sk, where e = H(r || H(m))
+//
+// USAGE:
+//
+//	// Generate keypair
+//	sk := curve.SampleScalar()
+//	pk := SchnorrPkFromSk(sk)
+//
+//	// Hash message (caller's responsibility)
+//	hashedMsg := p2.HashToQuinticExtension(messageFieldElements)
+//
+//	// Sign
+//	sig := SchnorrSignHashedMessage(hashedMsg, sk)
+//
+//	// Verify
+//	valid := IsSchnorrSignatureValid(pk, hashedMsg, sig)
+//
+// SECURITY CONSIDERATIONS:
+//
+// The lack of cofactor eliminates an entire class of attacks that affect
+// other elliptic curves (e.g., Ed25519's cofactor of 8). No special validation
+// is required beyond canonical encoding checks.
+//
+// Reference: https://github.com/pornin/ecgfp5
 package signature
 
 import (
@@ -62,6 +101,17 @@ func SchnorrSignHashedMessage(hashedMsg gFp5.Element, sk curve.ECgFp5Scalar) Sig
 	copy(preImage[:5], r[:])
 	copy(preImage[5:], hashedMsg[:])
 
+	// It is possible that we only use 128 bits for e (instread of 320 bits)
+	// That is, we can build e with the first 3 limbs of p2.HashToQuinticExtension(preImage)
+	// This should improve the performance of schnorr signature.
+	//
+	// see
+	//
+	// - Hash Function Requirements for Schnorr Signatures
+	//   Gregory Neven, Nigel P. Smart, and Bogdan Warinschi
+	// - Short Schnorr Signatures Require a Hash Function with More Than Just Random-Prefix Resistance
+	// 	 Daniel R. L. Brown
+
 	e := curve.FromGfp5(p2.HashToQuinticExtension(preImage))
 	return Signature{
 		S: k.Sub(e.Mul(sk)),
@@ -75,6 +125,17 @@ func SchnorrSignHashedMessage2(hashedMsg gFp5.Element, sk, k curve.ECgFp5Scalar)
 	preImage := make([]g.GoldilocksField, 5+5)
 	copy(preImage[:5], r[:])
 	copy(preImage[5:], hashedMsg[:])
+
+	// It is possible that we only use 128 bits for e (instread of 320 bits)
+	// That is, we can build e with the first 3 limbs of p2.HashToQuinticExtension(preImage)
+	// This should improve the performance of schnorr signature.
+	//
+	// see
+	//
+	// - Hash Function Requirements for Schnorr Signatures
+	//   Gregory Neven, Nigel P. Smart, and Bogdan Warinschi
+	// - Short Schnorr Signatures Require a Hash Function with More Than Just Random-Prefix Resistance
+	// 	 Daniel R. L. Brown
 
 	e := curve.FromGfp5(p2.HashToQuinticExtension(preImage))
 	return Signature{
@@ -105,11 +166,26 @@ func Validate(pubKey, hashedMsg, sig []byte) error {
 	return nil
 }
 
+// IsSchnorrSignatureValid verifies a Schnorr signature over the ECgFp5 curve.
+//
+// SECURITY NOTE - No Subgroup Checks Required:
+// Unlike many elliptic curve signature schemes, ECgFp5 has PRIME ORDER with no cofactor.
+// This means all successfully decoded points are in the prime-order group and no cofactor clearing is needed
+//
+// The verification only needs to check:
+// 1. Signature canonicality (S, E < group order)
+// 2. Public key decodes successfully (canonical encoding)
+// 3. Verification equation: s·G + e·pk = r, where e = H(r || H(m))
+//
+// Returns true if signature is valid, false otherwise.
 func IsSchnorrSignatureValid(pubKey, hashedMsg gFp5.Element, sig Signature) bool {
+	// Check signature canonicality (prevents malleability)
 	if !sig.IsCanonical() {
 		return false
 	}
 
+	// Decode public key (canonical decoding automatically ensures valid group element)
+	// No subgroup check needed due to prime order!
 	pubKeyWs, ok := curve.DecodeFp5AsWeierstrass(pubKey)
 	if !ok {
 		return false


### PR DESCRIPTION
- Added detailed documentation to ECgFp5 point and scalar field code, clarifying group law, canonical encoding, and security properties. 
- Enforced canonical input checks in scalar multiplication and Montgomery multiplication, with panics on invalid input. 
- Updated tests to verify rejection of non-canonical scalars and correct handling of canonical cases. 
- Improved Schnorr signature documentation, emphasizing prime order, canonical encoding, and the **absence of cofactor-related attacks**.