### PR TITLE
update Sign API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ vendor/
 # Go workspace file
 go.work
 go.work.sum
+.gocache
 
 # env file
 .env

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2_test.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2_test.go
@@ -112,15 +112,13 @@ func TestDigest(t *testing.T) {
 	inputs[1][6] = 1
 	inputs[1][7] = 0
 
-	g1 := g.FromCanonicalLittleEndianBytesF(inputs[0]) // 289077004332300282
-	g2 := g.FromCanonicalLittleEndianBytesF(inputs[1]) // 289644378102298614
-
 	hFunc.Write(inputs[0])
 	hFunc.Write(inputs[1])
 
 	hash := hFunc.Sum(nil)
 
-	hash2Elems := HashNoPad([]g.GoldilocksField{g1, g2})
+	messageBytes := append(append([]byte{}, inputs[0]...), inputs[1]...)
+	hash2Elems := HashNToHashNoPad(bytesToFieldElements(messageBytes))
 	hash2 := hash2Elems.ToLittleEndianBytes()
 
 	if !bytes.Equal(hash, hash2) {
@@ -173,27 +171,19 @@ func TestHashNToHashNoPad(t *testing.T) {
 }
 
 func TestHashNToHashNoPadLarge(t *testing.T) {
-	res := HashNToHashNoPad([]g.GoldilocksField{
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("HashNToHashNoPad should panic on non-canonical input (value >= ORDER)")
+		}
+	}()
+
+	HashNToHashNoPad([]g.GoldilocksField{
 		g.GoldilocksField(g.ORDER + 1),
 		g.GoldilocksField(g.ORDER + 2),
 		g.GoldilocksField(g.ORDER + 3),
 		g.GoldilocksField(math.MaxUint64),
 		g.GoldilocksField(math.MaxUint64 - 1),
 	})
-
-	expected := HashOut{
-		14216040864787980138,
-		17275303675000904868,
-		11831395338463193314,
-		281267649235863375,
-	}
-
-	for i := 0; i < 4; i++ {
-		if res[i] != expected[i] {
-			t.Logf("Expected: %v, got: %v\n", expected, res)
-			t.FailNow()
-		}
-	}
 }
 
 func TestHashTwoToOne(t *testing.T) {
@@ -300,4 +290,56 @@ func TestConstantsAreInTheField(t *testing.T) {
 			t.Fail()
 		}
 	}
+}
+
+func TestHashNToMNoPadBytesMatchesFieldHashSingleChunk(t *testing.T) {
+	input := []byte{1, 2, 3, 4, 5, 6, 7}
+	expected := HashNToMNoPad(bytesToFieldElements(input), 4)
+	result := HashNToMNoPadBytes(input, 4)
+
+	compareFieldSlices(t, result, expected)
+}
+
+func TestHashNToMNoPadBytesMatchesFieldHashPartialChunk(t *testing.T) {
+	input := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	expected := HashNToMNoPad(bytesToFieldElements(input), 4)
+	result := HashNToMNoPadBytes(input, 4)
+
+	compareFieldSlices(t, result, expected)
+}
+
+func compareFieldSlices(t *testing.T, got, want []g.GoldilocksField) {
+	if len(got) != len(want) {
+		t.Fatalf("expected %d output elements, got %d", len(want), len(got))
+	}
+
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("expected element %d to be %d, got %d", i, want[i], got[i])
+		}
+	}
+}
+
+func bytesToFieldElements(input []byte) []g.GoldilocksField {
+	absorbLen := g.Bytes - 1
+	if len(input) == 0 {
+		return nil
+	}
+
+	chunkCount := (len(input) + absorbLen - 1) / absorbLen
+	fields := make([]g.GoldilocksField, chunkCount)
+
+	for i := 0; i < chunkCount; i++ {
+		start := i * absorbLen
+		end := start + absorbLen
+		if end > len(input) {
+			end = len(input)
+		}
+
+		var paddedChunk [g.Bytes]byte
+		copy(paddedChunk[:], input[start:end])
+		fields[i] = g.FromCanonicalLittleEndianBytesF(paddedChunk[:])
+	}
+
+	return fields
 }

--- a/signature/schnorr/schnorr.go
+++ b/signature/schnorr/schnorr.go
@@ -93,10 +93,20 @@ func SchnorrPkFromSk(sk curve.ECgFp5Scalar) gFp5.Element {
 	return curve.GENERATOR_ECgFp5Point.Mul(sk).Encode()
 }
 
+// Sign the bytes; with the assumption that each 8 bytes is mapped to a canonical Field elements
+func SchnorrSignCanonicalBytes(msg []byte, sk curve.ECgFp5Scalar) Signature {
+	// Hash bytes directly to quintic extension (5 field elements)
+	msgElements := p2.HashNToMCanonicalBytes(msg, 5)
+	// we are sure msgElements are in the cononical form already
+	hashedMsg := gFp5.FromPlonky2GoldilocksField(msgElements)
+	// Sign the hashed message
+	return schnorrSignHashedMessage(hashedMsg, sk)
+}
+
 // Signing arbitrary length bytes.
 func SchnorrSignBytes(msg []byte, sk curve.ECgFp5Scalar) Signature {
 	// Hash bytes directly to quintic extension (5 field elements)
-	msgElements := p2.HashNToMNoPadBytes(msg, 5)
+	msgElements := p2.HashNToMPadBytes(msg, 5)
 	// we are sure msgElements are in the cononical form already
 	hashedMsg := gFp5.FromPlonky2GoldilocksField(msgElements)
 	// Sign the hashed message


### PR DESCRIPTION
the Sign algorithm now has three APIs:

- sign arbitrary bytes (new): in this setup, the message is uniquely hashed to a set of elements
- sign canonical bytes (previously sign bytes): in this setup, the message must already be in the right shape: serialized bytes from canonical form of the field elements. otherwise the sign will fail. **this is for backwords compatibility; it needs to be called with extreme care, and should be deprecated**
- sign field elements: the message field elements be in the right shape. the sign will fail if the field elements is not in the right form