### PR TITLE
Speed optimizations for poseidon2_goldilocks_plonky2 and field.

### DIFF
--- a/field/goldilocks/goldilocks_plonky2.go
+++ b/field/goldilocks/goldilocks_plonky2.go
@@ -56,10 +56,7 @@ func (z GoldilocksField) ToCanonicalUint64() uint64 {
 func AddF(lhs, rhs GoldilocksField) GoldilocksField {
 	sum, over := bits.Add64(uint64(lhs), uint64(rhs), 0)
 	sum, over = bits.Add64(sum, over*EPSILON, 0)
-	if over == 1 {
-		branchHint()
-		sum += EPSILON // this can't overflow
-	}
+	sum += EPSILON * over // this can't overflow
 
 	return GoldilocksField(sum)
 }
@@ -79,10 +76,7 @@ func DoubleF(lhs GoldilocksField) GoldilocksField {
 func SubF(lhs, rhs GoldilocksField) GoldilocksField {
 	diff, borrow := bits.Sub64(uint64(lhs), uint64(rhs), 0)
 	diff, borrow = bits.Sub64(diff, borrow*EPSILON, 0)
-	if borrow == 1 {
-		branchHint()
-		diff -= EPSILON // this can't underflow
-	}
+	diff -= EPSILON * borrow // this can't underflow
 
 	return GoldilocksField(diff)
 }
@@ -95,10 +89,8 @@ func MulF(lhs, rhs GoldilocksField) GoldilocksField {
 	x_hi_lo := x_hi & EPSILON
 
 	t0, borrow := bits.Sub64(x_lo, x_hi_hi, 0)
-	if borrow == 1 {
-		branchHint()
-		t0 -= EPSILON
-	}
+	t0 -= EPSILON * borrow
+
 	t1 := x_hi_lo * EPSILON
 
 	sum, over := bits.Add64(t0, t1, 0)
@@ -112,8 +104,14 @@ func SquareF(x GoldilocksField) GoldilocksField {
 
 // Returns self + x * y
 func MulAccF(self, x, y GoldilocksField) GoldilocksField {
-	// u64 + u64 * u64 cannot overflow.
-	return Reduce128Bit(AddUInt128(AsUInt128(self), MulUInt64(uint64(x), uint64(y))))
+	hi, lo := bits.Mul64(uint64(x), uint64(y))
+	lo, c := bits.Add64(lo, uint64(self), 0)
+	hi += c
+
+	t0, borrow := bits.Sub64(lo, hi>>32, 0)
+	t0 -= EPSILON * borrow
+	resWrapped, c := bits.Add64(t0, (hi&EPSILON)*EPSILON, 0)
+	return GoldilocksField(resWrapped + EPSILON*c)
 }
 
 func ExpPowerOf2(x GoldilocksField, n uint) GoldilocksField {
@@ -187,10 +185,8 @@ func Reduce128Bit(x UInt128) GoldilocksField {
 	x_hi_lo := x.Hi & EPSILON
 
 	t0, borrow := bits.Sub64(x.Lo, x_hi_hi, 0)
-	if borrow == 1 {
-		branchHint()
-		t0 -= EPSILON
-	}
+	t0 -= EPSILON * borrow
+
 	t1 := x_hi_lo * EPSILON
 
 	resWrapped, carry := bits.Add64(t0, t1, 0)

--- a/field/goldilocks/goldilocks_plonky2_test.go
+++ b/field/goldilocks/goldilocks_plonky2_test.go
@@ -1,0 +1,107 @@
+package goldilocks
+
+import (
+	"math/bits"
+	"math/rand"
+	"testing"
+)
+
+func getRandomGoldilocks() GoldilocksField {
+	return GoldilocksField(rand.Uint64())
+}
+
+// Tests for multiplication
+
+func MulF_Test1(lhs, rhs GoldilocksField) GoldilocksField {
+	x_hi, x_lo := bits.Mul64(uint64(lhs), uint64(rhs))
+
+	x_hi_hi := x_hi >> 32
+	x_hi_lo := x_hi & EPSILON
+
+	t0, borrow := bits.Sub64(x_lo, x_hi_hi, 0)
+	if borrow == 1 {
+		branchHint()
+		t0 -= EPSILON
+	}
+	t1 := x_hi_lo * EPSILON
+
+	sum, over := bits.Add64(t0, t1, 0)
+	t2 := sum + EPSILON*over
+	return GoldilocksField(t2)
+}
+
+func MulF_Test2(lhs, rhs GoldilocksField) GoldilocksField {
+	x_hi, x_lo := bits.Mul64(uint64(lhs), uint64(rhs))
+
+	x_hi_hi := x_hi >> 32
+	x_hi_lo := x_hi & EPSILON
+
+	t0, borrow := bits.Sub64(x_lo, x_hi_hi, 0)
+	if borrow == 1 {
+		t0 -= EPSILON
+	}
+	t1 := x_hi_lo * EPSILON
+
+	sum, over := bits.Add64(t0, t1, 0)
+	t2 := sum + EPSILON*over
+	return GoldilocksField(t2)
+}
+
+func MulF_Test3(lhs, rhs GoldilocksField) GoldilocksField {
+	x_hi, x_lo := bits.Mul64(uint64(lhs), uint64(rhs))
+
+	x_hi_hi := x_hi >> 32
+	x_hi_lo := x_hi & EPSILON
+
+	t0, borrow := bits.Sub64(x_lo, x_hi_hi, 0)
+	t0 -= EPSILON * borrow
+	t1 := x_hi_lo * EPSILON
+
+	sum, over := bits.Add64(t0, t1, 0)
+	t2 := sum + EPSILON*over
+	return GoldilocksField(t2)
+}
+
+func BenchmarkMulF(b *testing.B) {
+	len := 10000000
+	x := make([]GoldilocksField, len)
+	y := make([]GoldilocksField, len)
+	for i := 0; i < len; i++ {
+		x[i] = getRandomGoldilocks()
+		y[i] = getRandomGoldilocks()
+	}
+	var res GoldilocksField
+	id := 0
+	b.Run("Original-MulF", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			res = MulF_Test1(x[id], y[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+
+	id = 0
+	b.Run("No-BranchHint-MulF", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			res = MulF_Test2(x[id], y[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+
+	id = 0
+	b.Run("Branchless-MulF", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			res = MulF_Test3(x[id], y[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+	_ = res
+}

--- a/field/goldilocks/goldilocks_plonky2_test.go
+++ b/field/goldilocks/goldilocks_plonky2_test.go
@@ -2,7 +2,7 @@ package goldilocks
 
 import (
 	"math/bits"
-	"math/rand"
+	rand "math/rand/v2"
 	"testing"
 )
 

--- a/field/goldilocks/goldilocks_plonky2_test.go
+++ b/field/goldilocks/goldilocks_plonky2_test.go
@@ -1,13 +1,16 @@
 package goldilocks
 
 import (
+	rand "crypto/rand"
+	"math/big"
 	"math/bits"
-	rand "math/rand/v2"
 	"testing"
 )
 
 func getRandomGoldilocks() GoldilocksField {
-	return GoldilocksField(rand.Uint64())
+	mx := new(big.Int).SetUint64(0xFFFFFFFF00000000) // ORDER - 1
+	a, _ := rand.Int(rand.Reader, mx)
+	return GoldilocksField(a.Uint64())
 }
 
 // Tests for multiplication

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -372,8 +372,7 @@ func (d *digest) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// Sum appends the current hash to b and returns the resulting slice.
-// It does not change the underlying hash state.
+// Sum writes onto the slices given. Be cautious using it.
 func (d *digest) Sum(b []byte) []byte {
 	if len(b) < 32 { // Just a quick check
 		b = make([]byte, 32)

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -126,8 +126,8 @@ func HashNToMNoPadBytes(input []byte, numOutputs int) []g.GoldilocksField {
 }
 
 // Output size is assumed to be 32 bytes.
-// Input sizes can be only 8 bytes, or 0 bytes.
-func HashNToMNoPadBytesOptimized(left, right []byte) []byte {
+// Input sizes can be only 0 or 32 bytes.
+func HashPair(left, right []byte) []byte {
 	if !((len(left) == 0 || len(left) == 32) && (len(right) == 0 || len(right) == 32)) {
 		panic("input lengths should be 32 or 0")
 	}
@@ -213,7 +213,7 @@ func externalLinearLayer128(s *[WIDTH]UInt128) {
 	s[2] = AddUInt128(AddUInt128(t0123, t23), x3)
 	s[3] = AddUInt128(AddUInt128(t0123, x3), AddUInt128(x0, x0))
 
-	// chunk 2
+	// chunk 1
 	x0, x1, x2, x3 = s[4], s[5], s[6], s[7]
 	t01 = AddUInt128(x0, x1)
 	t23 = AddUInt128(x2, x3)
@@ -223,7 +223,7 @@ func externalLinearLayer128(s *[WIDTH]UInt128) {
 	s[6] = AddUInt128(AddUInt128(t0123, t23), x3)
 	s[7] = AddUInt128(AddUInt128(t0123, x3), AddUInt128(x0, x0))
 
-	// chunk 3
+	// chunk 2
 	x0, x1, x2, x3 = s[8], s[9], s[10], s[11]
 	t01 = AddUInt128(x0, x1)
 	t23 = AddUInt128(x2, x3)

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -142,7 +142,14 @@ func fullRounds(state *[WIDTH]g.GoldilocksField, start int) {
 func partialRounds(state *[WIDTH]g.GoldilocksField) {
 	for r := 0; r < ROUNDS_P; r++ {
 		addRCI(state, r)
-		sboxP(0, state)
+
+		// Manual-inlining for sboxP
+		p := state[0]
+		p2 := g.SquareF(p)       // x^2
+		p4 := g.SquareF(p2)      // x^4
+		p = g.MulF(p, p2)        // x^3
+		state[0] = g.MulF(p, p4) // x^7
+
 		internalLinearLayer(state)
 	}
 }
@@ -161,28 +168,57 @@ func externalLinearLayer(s *[WIDTH]g.GoldilocksField) {
 }
 
 func externalLinearLayer128(s *[WIDTH]UInt128) {
-	for i := 0; i < WIDTH; i += 4 {
-		t01 := AddUInt128(s[i], s[i+1])
-		t23 := AddUInt128(s[i+2], s[i+3])
-		t0123 := AddUInt128(t01, t23)
+	// chunk 0
+	x0, x1, x2, x3 := s[0], s[1], s[2], s[3]
+	t01 := AddUInt128(x0, x1)
+	t23 := AddUInt128(x2, x3)
+	t0123 := AddUInt128(t01, t23)
+	s[0] = AddUInt128(AddUInt128(t0123, t01), x1)
+	s[1] = AddUInt128(AddUInt128(t0123, x1), AddUInt128(x2, x2))
+	s[2] = AddUInt128(AddUInt128(t0123, t23), x3)
+	s[3] = AddUInt128(AddUInt128(t0123, x3), AddUInt128(x0, x0))
 
-		x0 := s[i]
-		x2 := s[i+2]
+	// chunk 2
+	x0, x1, x2, x3 = s[4], s[5], s[6], s[7]
+	t01 = AddUInt128(x0, x1)
+	t23 = AddUInt128(x2, x3)
+	t0123 = AddUInt128(t01, t23)
+	s[4] = AddUInt128(AddUInt128(t0123, t01), x1)
+	s[5] = AddUInt128(AddUInt128(t0123, x1), AddUInt128(x2, x2))
+	s[6] = AddUInt128(AddUInt128(t0123, t23), x3)
+	s[7] = AddUInt128(AddUInt128(t0123, x3), AddUInt128(x0, x0))
 
-		s[i] = AddUInt128(AddUInt128(t0123, t01), s[i+1])
-		s[i+1] = AddUInt128(AddUInt128(AddUInt128(t0123, s[i+1]), x2), x2)
-		s[i+2] = AddUInt128(AddUInt128(t0123, t23), s[i+3])
-		s[i+3] = AddUInt128(AddUInt128(AddUInt128(t0123, s[i+3]), x0), x0)
-	}
+	// chunk 3
+	x0, x1, x2, x3 = s[8], s[9], s[10], s[11]
+	t01 = AddUInt128(x0, x1)
+	t23 = AddUInt128(x2, x3)
+	t0123 = AddUInt128(t01, t23)
+	s[8] = AddUInt128(AddUInt128(t0123, t01), x1)
+	s[9] = AddUInt128(AddUInt128(t0123, x1), AddUInt128(x2, x2))
+	s[10] = AddUInt128(AddUInt128(t0123, t23), x3)
+	s[11] = AddUInt128(AddUInt128(t0123, x3), AddUInt128(x0, x0))
 
 	sums := [4]UInt128{}
-	for i := 0; i < 4; i++ {
-		sums[i] = AddUInt128(AddUInt128(s[i], s[i+4]), s[i+8])
-	}
+	sums[0] = AddUInt128(s[0], AddUInt128(s[4], s[8]))
+	sums[1] = AddUInt128(s[1], AddUInt128(s[5], s[9]))
+	sums[2] = AddUInt128(s[2], AddUInt128(s[6], s[10]))
+	sums[3] = AddUInt128(s[3], AddUInt128(s[7], s[11]))
 
-	for i := 0; i < WIDTH; i++ {
-		s[i] = AddUInt128(s[i], sums[i%4])
-	}
+	s[0] = AddUInt128(s[0], sums[0])
+	s[4] = AddUInt128(s[4], sums[0])
+	s[8] = AddUInt128(s[8], sums[0])
+
+	s[1] = AddUInt128(s[1], sums[1])
+	s[5] = AddUInt128(s[5], sums[1])
+	s[9] = AddUInt128(s[9], sums[1])
+
+	s[2] = AddUInt128(s[2], sums[2])
+	s[6] = AddUInt128(s[6], sums[2])
+	s[10] = AddUInt128(s[10], sums[2])
+
+	s[3] = AddUInt128(s[3], sums[3])
+	s[7] = AddUInt128(s[7], sums[3])
+	s[11] = AddUInt128(s[11], sums[3])
 }
 
 func internalLinearLayer(state *[WIDTH]g.GoldilocksField) {
@@ -225,20 +261,64 @@ func addRCI(state *[WIDTH]g.GoldilocksField, round int) {
 }
 
 func sbox(state *[WIDTH]g.GoldilocksField) {
-	for i := range state {
-		sboxP(i, state)
-	}
+	// group 0-5
+	p0_2 := g.SquareF(state[0])
+	p1_2 := g.SquareF(state[1])
+	p2_2 := g.SquareF(state[2])
+	p3_2 := g.SquareF(state[3])
+	p4_2 := g.SquareF(state[4])
+	p5_2 := g.SquareF(state[5])
+	p0_3 := g.MulF(state[0], p0_2)
+	p0_4 := g.SquareF(p0_2)
+	p1_3 := g.MulF(state[1], p1_2)
+	p1_4 := g.SquareF(p1_2)
+	p2_3 := g.MulF(state[2], p2_2)
+	p2_4 := g.SquareF(p2_2)
+	p3_3 := g.MulF(state[3], p3_2)
+	p3_4 := g.SquareF(p3_2)
+	p4_3 := g.MulF(state[4], p4_2)
+	p4_4 := g.SquareF(p4_2)
+	p5_3 := g.MulF(state[5], p5_2)
+	p5_4 := g.SquareF(p5_2)
+	state[0] = g.MulF(p0_3, p0_4)
+	state[1] = g.MulF(p1_3, p1_4)
+	state[2] = g.MulF(p2_3, p2_4)
+	state[3] = g.MulF(p3_3, p3_4)
+	state[4] = g.MulF(p4_3, p4_4)
+	state[5] = g.MulF(p5_3, p5_4)
+
+	// group 6-11
+	p6_2 := g.SquareF(state[6])
+	p7_2 := g.SquareF(state[7])
+	p8_2 := g.SquareF(state[8])
+	p9_2 := g.SquareF(state[9])
+	p10_2 := g.SquareF(state[10])
+	p11_2 := g.SquareF(state[11])
+	p6_3 := g.MulF(state[6], p6_2)
+	p6_4 := g.SquareF(p6_2)
+	p7_3 := g.MulF(state[7], p7_2)
+	p7_4 := g.SquareF(p7_2)
+	p8_3 := g.MulF(state[8], p8_2)
+	p8_4 := g.SquareF(p8_2)
+	p9_3 := g.MulF(state[9], p9_2)
+	p9_4 := g.SquareF(p9_2)
+	p10_3 := g.MulF(state[10], p10_2)
+	p10_4 := g.SquareF(p10_2)
+	p11_3 := g.MulF(state[11], p11_2)
+	p11_4 := g.SquareF(p11_2)
+	state[6] = g.MulF(p6_3, p6_4)
+	state[7] = g.MulF(p7_3, p7_4)
+	state[8] = g.MulF(p8_3, p8_4)
+	state[9] = g.MulF(p9_3, p9_4)
+	state[10] = g.MulF(p10_3, p10_4)
+	state[11] = g.MulF(p11_3, p11_4)
 }
 
-func sboxP(index int, state *[WIDTH]g.GoldilocksField) {
-	tmp := state[index]
-	tmpSquare := g.SquareF(tmp)
-
-	var tmpSixth g.GoldilocksField
-	tmpSixth = g.MulF(tmpSquare, tmp)
-	tmpSixth = g.SquareF(tmpSixth)
-
-	state[index] = g.MulF(tmpSixth, tmp)
+func sboxP(state g.GoldilocksField) g.GoldilocksField {
+	p2 := g.SquareF(state)    // x^2
+	p4 := g.SquareF(p2)       // x^4
+	state = g.MulF(state, p2) // x^3
+	return g.MulF(state, p4)  // x^7
 }
 
 const BlockSize = g.Bytes * WIDTH // BlockSize size that poseidon consumes

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -124,6 +124,27 @@ func HashNToMNoPadBytes(input []byte, numOutputs int) []g.GoldilocksField {
 	}
 }
 
+func HashNToMNoPadBytesOptimized(input []byte, output []byte) []byte {
+	if len(input)%g.Bytes != 0 {
+		panic("input length should be multiple of 8")
+	}
+
+	inputLen := len(input) / g.Bytes
+
+	var perm [WIDTH]g.GoldilocksField
+	for j := 0; j < inputLen; j++ {
+		index := j * g.Bytes
+		perm[j] = g.FromCanonicalLittleEndianBytesF(input[index : index+g.Bytes])
+	}
+	Permute(&perm)
+
+	output = append(output, g.ToLittleEndianBytesF(perm[0])...)
+	output = append(output, g.ToLittleEndianBytesF(perm[1])...)
+	output = append(output, g.ToLittleEndianBytesF(perm[2])...)
+	output = append(output, g.ToLittleEndianBytesF(perm[3])...)
+	return output
+}
+
 func Permute(input *[WIDTH]g.GoldilocksField) {
 	externalLinearLayer(input)
 	fullRounds(input, 0)
@@ -350,13 +371,8 @@ func (d *digest) Write(p []byte) (n int, err error) {
 // Sum appends the current hash to b and returns the resulting slice.
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
-	h := HashNToMNoPadBytes(d.data, 4)
+	b = HashNToMNoPadBytesOptimized(d.data, b)
 	d.Reset()
-
-	for _, elem := range h {
-		b = append(b, g.ToLittleEndianBytesF(elem)...)
-	}
-
 	return b
 }
 

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -140,10 +140,10 @@ func HashNToMNoPadBytesOptimized(input []byte, output []byte) []byte {
 	}
 	Permute(&perm)
 
-	output = append(output, g.ToLittleEndianBytesF(perm[0])...)
-	output = append(output, g.ToLittleEndianBytesF(perm[1])...)
-	output = append(output, g.ToLittleEndianBytesF(perm[2])...)
-	output = append(output, g.ToLittleEndianBytesF(perm[3])...)
+	copy(output[0:8], g.ToLittleEndianBytesF(perm[0]))
+	copy(output[8:16], g.ToLittleEndianBytesF(perm[1]))
+	copy(output[16:24], g.ToLittleEndianBytesF(perm[2]))
+	copy(output[24:], g.ToLittleEndianBytesF(perm[3]))
 	return output
 }
 
@@ -373,6 +373,9 @@ func (d *digest) Write(p []byte) (n int, err error) {
 // Sum appends the current hash to b and returns the resulting slice.
 // It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
+	if len(b) < 32 { // Just a quick check
+		b = make([]byte, 32)
+	}
 	b = HashNToMNoPadBytesOptimized(d.data, b)
 	d.Reset()
 	return b

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -125,7 +125,7 @@ func HashNToMNoPadBytes(input []byte, numOutputs int) []g.GoldilocksField {
 }
 
 // Output size is assumed to be 32 bytes.
-// Input size can be 0 or 4 or 8 bytes.
+// Input size can be 0 or 8 bytes.
 func HashNToMNoPadBytesOptimized(input []byte, output []byte) []byte {
 	if len(input)%g.Bytes != 0 {
 		panic("input length should be multiple of 8")
@@ -134,7 +134,7 @@ func HashNToMNoPadBytesOptimized(input []byte, output []byte) []byte {
 	inputLen := len(input) / g.Bytes
 
 	var perm [WIDTH]g.GoldilocksField
-	for j := 0; j < inputLen; j++ {
+	for j := 0; j < min(inputLen, 8); j++ {
 		index := j * g.Bytes
 		perm[j] = g.FromCanonicalLittleEndianBytesF(input[index : index+g.Bytes])
 	}

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -126,20 +126,24 @@ func HashNToMNoPadBytes(input []byte, numOutputs int) []g.GoldilocksField {
 }
 
 // Output size is assumed to be 32 bytes.
-// Input size can be 0 or 8 bytes. Do not use for input length > 8.
-func HashNToMNoPadBytesOptimized(input []byte, output []byte) []byte {
-	if len(input)%g.Bytes != 0 {
-		panic("input length should be multiple of 8")
+// Input sizes can be only 8 bytes.
+func HashNToMNoPadBytesOptimized(left, right []byte) []byte {
+	if !(len(left) == 32 && len(right) == 32) {
+		panic("input lengths should be 32")
 	}
-
-	inputLen := len(input) / g.Bytes
 
 	var perm [WIDTH]g.GoldilocksField
-	for j := 0; j < min(inputLen, 8); j++ {
+	for j := 0; j < 4; j++ {
 		index := j * g.Bytes
-		perm[j] = g.FromCanonicalLittleEndianBytesF(input[index : index+g.Bytes])
+		perm[j] = g.FromCanonicalLittleEndianBytesF(left[index : index+g.Bytes])
+	}
+	for j := 0; j < 4; j++ {
+		index := j * g.Bytes
+		perm[j+4] = g.FromCanonicalLittleEndianBytesF(right[index : index+g.Bytes])
 	}
 	Permute(&perm)
+
+	output := make([]byte, 32)
 
 	binary.LittleEndian.PutUint64(output[0:8], perm[0].ToCanonicalUint64())
 	binary.LittleEndian.PutUint64(output[8:16], perm[1].ToCanonicalUint64())
@@ -372,13 +376,16 @@ func (d *digest) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
 
-// Sum writes onto the slices given. Be cautious using it.
+// Sum appends the current hash to b and returns the resulting slice.
+// It does not change the underlying hash state.
 func (d *digest) Sum(b []byte) []byte {
-	if len(b) < 32 { // Just a quick check
-		b = make([]byte, 32)
-	}
-	b = HashNToMNoPadBytesOptimized(d.data, b)
+	h := HashNToMNoPadBytes(d.data, 4)
 	d.Reset()
+
+	for _, elem := range h {
+		b = append(b, g.ToLittleEndianBytesF(elem)...)
+	}
+
 	return b
 }
 

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -126,21 +126,27 @@ func HashNToMNoPadBytes(input []byte, numOutputs int) []g.GoldilocksField {
 }
 
 // Output size is assumed to be 32 bytes.
-// Input sizes can be only 8 bytes.
+// Input sizes can be only 8 bytes, or 0 bytes.
 func HashNToMNoPadBytesOptimized(left, right []byte) []byte {
-	if !(len(left) == 32 && len(right) == 32) {
-		panic("input lengths should be 32")
+	if !((len(left) == 0 || len(left) == 32) && (len(right) == 0 || len(right) == 32)) {
+		panic("input lengths should be 32 or 0")
 	}
 
 	var perm [WIDTH]g.GoldilocksField
-	for j := 0; j < 4; j++ {
-		index := j * g.Bytes
-		perm[j] = g.FromCanonicalLittleEndianBytesF(left[index : index+g.Bytes])
+
+	if len(left) == 32 {
+		for j := 0; j < 4; j++ {
+			index := j * g.Bytes
+			perm[j] = g.FromCanonicalLittleEndianBytesF(left[index : index+g.Bytes])
+		}
 	}
-	for j := 0; j < 4; j++ {
-		index := j * g.Bytes
-		perm[j+4] = g.FromCanonicalLittleEndianBytesF(right[index : index+g.Bytes])
+	if len(right) == 32 {
+		for j := 0; j < 4; j++ {
+			index := j * g.Bytes
+			perm[j+4] = g.FromCanonicalLittleEndianBytesF(right[index : index+g.Bytes])
+		}
 	}
+
 	Permute(&perm)
 
 	output := make([]byte, 32)

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -1,6 +1,7 @@
 package poseidon2_plonky2
 
 import (
+	"encoding/binary"
 	"fmt"
 	"hash"
 
@@ -125,7 +126,7 @@ func HashNToMNoPadBytes(input []byte, numOutputs int) []g.GoldilocksField {
 }
 
 // Output size is assumed to be 32 bytes.
-// Input size can be 0 or 8 bytes.
+// Input size can be 0 or 8 bytes. Do not use for input length > 8.
 func HashNToMNoPadBytesOptimized(input []byte, output []byte) []byte {
 	if len(input)%g.Bytes != 0 {
 		panic("input length should be multiple of 8")
@@ -140,10 +141,11 @@ func HashNToMNoPadBytesOptimized(input []byte, output []byte) []byte {
 	}
 	Permute(&perm)
 
-	copy(output[0:8], g.ToLittleEndianBytesF(perm[0]))
-	copy(output[8:16], g.ToLittleEndianBytesF(perm[1]))
-	copy(output[16:24], g.ToLittleEndianBytesF(perm[2]))
-	copy(output[24:], g.ToLittleEndianBytesF(perm[3]))
+	binary.LittleEndian.PutUint64(output[0:8], perm[0].ToCanonicalUint64())
+	binary.LittleEndian.PutUint64(output[8:16], perm[1].ToCanonicalUint64())
+	binary.LittleEndian.PutUint64(output[16:24], perm[2].ToCanonicalUint64())
+	binary.LittleEndian.PutUint64(output[24:], perm[3].ToCanonicalUint64())
+
 	return output
 }
 

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2.go
@@ -124,6 +124,8 @@ func HashNToMNoPadBytes(input []byte, numOutputs int) []g.GoldilocksField {
 	}
 }
 
+// Output size is assumed to be 32 bytes.
+// Input size can be 0 or 4 or 8 bytes.
 func HashNToMNoPadBytesOptimized(input []byte, output []byte) []byte {
 	if len(input)%g.Bytes != 0 {
 		panic("input length should be multiple of 8")

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2_test.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2_test.go
@@ -3,10 +3,17 @@ package poseidon2_plonky2
 import (
 	"bytes"
 	"math"
+	"math/bits"
+	"math/rand/v2"
 	"testing"
 
 	g "github.com/elliottech/poseidon_crypto/field/goldilocks"
+	. "github.com/elliottech/poseidon_crypto/int"
 )
+
+func getRandomGoldilocks() g.GoldilocksField {
+	return g.GoldilocksField(rand.Uint64())
+}
 
 func TestPermute(t *testing.T) {
 	inp := [WIDTH]g.GoldilocksField{
@@ -300,4 +307,412 @@ func TestConstantsAreInTheField(t *testing.T) {
 			t.Fail()
 		}
 	}
+}
+
+func mulAccF_test1(self, x, y g.GoldilocksField) g.GoldilocksField {
+	// u64 + u64 * u64 cannot overflow.
+	return g.Reduce128Bit(AddUInt128(g.AsUInt128(self), MulUInt64(uint64(x), uint64(y))))
+}
+
+func mulAccF_test2(self, x, y g.GoldilocksField) g.GoldilocksField {
+	hi, lo := bits.Mul64(uint64(x), uint64(y))
+	lo, c := bits.Add64(lo, uint64(self), 0)
+	hi += c
+
+	t0, borrow := bits.Sub64(lo, hi>>32, 0)
+	t0 -= g.EPSILON * borrow
+	resWrapped, c := bits.Add64(t0, (hi&g.EPSILON)*g.EPSILON, 0)
+	return g.GoldilocksField(resWrapped + g.EPSILON*c)
+}
+
+func mulAccF_test3(self, x, y g.GoldilocksField) g.GoldilocksField {
+	hi, lo := bits.Mul64(uint64(x), uint64(y))
+	lo, c := bits.Add64(lo, uint64(self), 0)
+	hi += c
+	return g.Reduce128Bit(UInt128{Hi: hi, Lo: lo})
+}
+
+func BenchmarkMulAccF(b *testing.B) {
+	len := 100000000
+	x := make([]g.GoldilocksField, len)
+	y := make([]g.GoldilocksField, len)
+	z := make([]g.GoldilocksField, len)
+	for i := 0; i < len; i++ {
+		x[i] = getRandomGoldilocks()
+		y[i] = getRandomGoldilocks()
+		z[i] = getRandomGoldilocks()
+	}
+	var res g.GoldilocksField
+	id := 0
+	b.Run("Original-MulAccF", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			res = mulAccF_test1(x[id], y[id], z[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+
+	id = 0
+	b.Run("Half-Inlined-MulF", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			res = mulAccF_test3(x[id], y[id], z[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+
+	id = 0
+	b.Run("Full-Inlined-MulF", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			res = mulAccF_test2(x[id], y[id], z[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+	_ = res
+}
+
+func sbox_test1(state *[12]g.GoldilocksField) {
+	// fully unrolled 3 passes
+	p2_0 := g.SquareF(state[0])
+	p2_1 := g.SquareF(state[1])
+	p2_2 := g.SquareF(state[2])
+	p2_3 := g.SquareF(state[3])
+	p2_4 := g.SquareF(state[4])
+	p2_5 := g.SquareF(state[5])
+	p2_6 := g.SquareF(state[6])
+	p2_7 := g.SquareF(state[7])
+	p2_8 := g.SquareF(state[8])
+	p2_9 := g.SquareF(state[9])
+	p2_10 := g.SquareF(state[10])
+	p2_11 := g.SquareF(state[11])
+
+	p3_0 := g.MulF(state[0], p2_0)
+	p4_0 := g.SquareF(p2_0)
+	p3_1 := g.MulF(state[1], p2_1)
+	p4_1 := g.SquareF(p2_1)
+	p3_2 := g.MulF(state[2], p2_2)
+	p4_2 := g.SquareF(p2_2)
+	p3_3 := g.MulF(state[3], p2_3)
+	p4_3 := g.SquareF(p2_3)
+	p3_4 := g.MulF(state[4], p2_4)
+	p4_4 := g.SquareF(p2_4)
+	p3_5 := g.MulF(state[5], p2_5)
+	p4_5 := g.SquareF(p2_5)
+	p3_6 := g.MulF(state[6], p2_6)
+	p4_6 := g.SquareF(p2_6)
+	p3_7 := g.MulF(state[7], p2_7)
+	p4_7 := g.SquareF(p2_7)
+	p3_8 := g.MulF(state[8], p2_8)
+	p4_8 := g.SquareF(p2_8)
+	p3_9 := g.MulF(state[9], p2_9)
+	p4_9 := g.SquareF(p2_9)
+	p3_10 := g.MulF(state[10], p2_10)
+	p4_10 := g.SquareF(p2_10)
+	p3_11 := g.MulF(state[11], p2_11)
+	p4_11 := g.SquareF(p2_11)
+
+	state[0] = g.MulF(p3_0, p4_0)
+	state[1] = g.MulF(p3_1, p4_1)
+	state[2] = g.MulF(p3_2, p4_2)
+	state[3] = g.MulF(p3_3, p4_3)
+	state[4] = g.MulF(p3_4, p4_4)
+	state[5] = g.MulF(p3_5, p4_5)
+	state[6] = g.MulF(p3_6, p4_6)
+	state[7] = g.MulF(p3_7, p4_7)
+	state[8] = g.MulF(p3_8, p4_8)
+	state[9] = g.MulF(p3_9, p4_9)
+	state[10] = g.MulF(p3_10, p4_10)
+	state[11] = g.MulF(p3_11, p4_11)
+}
+
+func sbox_test2(state *[12]g.GoldilocksField) {
+	// original single loop unroll
+	state[0] = sboxP(state[0])
+	state[1] = sboxP(state[1])
+	state[2] = sboxP(state[2])
+	state[3] = sboxP(state[3])
+	state[4] = sboxP(state[4])
+	state[5] = sboxP(state[5])
+	state[6] = sboxP(state[6])
+	state[7] = sboxP(state[7])
+	state[8] = sboxP(state[8])
+	state[9] = sboxP(state[9])
+	state[10] = sboxP(state[10])
+	state[11] = sboxP(state[11])
+}
+
+func sbox_group3(state *[WIDTH]g.GoldilocksField) {
+	// group 0-3
+	p2_0 := g.SquareF(state[0])
+	p2_1 := g.SquareF(state[1])
+	p2_2 := g.SquareF(state[2])
+	p2_3 := g.SquareF(state[3])
+	p3_0 := g.MulF(state[0], p2_0)
+	p4_0 := g.SquareF(p2_0)
+	p3_1 := g.MulF(state[1], p2_1)
+	p4_1 := g.SquareF(p2_1)
+	p3_2 := g.MulF(state[2], p2_2)
+	p4_2 := g.SquareF(p2_2)
+	p3_3 := g.MulF(state[3], p2_3)
+	p4_3 := g.SquareF(p2_3)
+	state[0] = g.MulF(p3_0, p4_0)
+	state[1] = g.MulF(p3_1, p4_1)
+	state[2] = g.MulF(p3_2, p4_2)
+	state[3] = g.MulF(p3_3, p4_3)
+
+	// group 4-7
+	p2_4 := g.SquareF(state[4])
+	p2_5 := g.SquareF(state[5])
+	p2_6 := g.SquareF(state[6])
+	p2_7 := g.SquareF(state[7])
+	p3_4 := g.MulF(state[4], p2_4)
+	p4_4 := g.SquareF(p2_4)
+	p3_5 := g.MulF(state[5], p2_5)
+	p4_5 := g.SquareF(p2_5)
+	p3_6 := g.MulF(state[6], p2_6)
+	p4_6 := g.SquareF(p2_6)
+	p3_7 := g.MulF(state[7], p2_7)
+	p4_7 := g.SquareF(p2_7)
+	state[4] = g.MulF(p3_4, p4_4)
+	state[5] = g.MulF(p3_5, p4_5)
+	state[6] = g.MulF(p3_6, p4_6)
+	state[7] = g.MulF(p3_7, p4_7)
+
+	// group 8-11
+	p2_8 := g.SquareF(state[8])
+	p2_9 := g.SquareF(state[9])
+	p2_10 := g.SquareF(state[10])
+	p2_11 := g.SquareF(state[11])
+	p3_8 := g.MulF(state[8], p2_8)
+	p4_8 := g.SquareF(p2_8)
+	p3_9 := g.MulF(state[9], p2_9)
+	p4_9 := g.SquareF(p2_9)
+	p3_10 := g.MulF(state[10], p2_10)
+	p4_10 := g.SquareF(p2_10)
+	p3_11 := g.MulF(state[11], p2_11)
+	p4_11 := g.SquareF(p2_11)
+	state[8] = g.MulF(p3_8, p4_8)
+	state[9] = g.MulF(p3_9, p4_9)
+	state[10] = g.MulF(p3_10, p4_10)
+	state[11] = g.MulF(p3_11, p4_11)
+}
+
+func sbox_group4(state *[WIDTH]g.GoldilocksField) {
+	// group 0-5
+	p0_2 := g.SquareF(state[0])
+	p1_2 := g.SquareF(state[1])
+	p2_2 := g.SquareF(state[2])
+	p3_2 := g.SquareF(state[3])
+	p4_2 := g.SquareF(state[4])
+	p5_2 := g.SquareF(state[5])
+	p0_3 := g.MulF(state[0], p0_2)
+	p0_4 := g.SquareF(p0_2)
+	p1_3 := g.MulF(state[1], p1_2)
+	p1_4 := g.SquareF(p1_2)
+	p2_3 := g.MulF(state[2], p2_2)
+	p2_4 := g.SquareF(p2_2)
+	p3_3 := g.MulF(state[3], p3_2)
+	p3_4 := g.SquareF(p3_2)
+	p4_3 := g.MulF(state[4], p4_2)
+	p4_4 := g.SquareF(p4_2)
+	p5_3 := g.MulF(state[5], p5_2)
+	p5_4 := g.SquareF(p5_2)
+	state[0] = g.MulF(p0_3, p0_4)
+	state[1] = g.MulF(p1_3, p1_4)
+	state[2] = g.MulF(p2_3, p2_4)
+	state[3] = g.MulF(p3_3, p3_4)
+	state[4] = g.MulF(p4_3, p4_4)
+	state[5] = g.MulF(p5_3, p5_4)
+
+	// group 6-11
+	p6_2 := g.SquareF(state[6])
+	p7_2 := g.SquareF(state[7])
+	p8_2 := g.SquareF(state[8])
+	p9_2 := g.SquareF(state[9])
+	p10_2 := g.SquareF(state[10])
+	p11_2 := g.SquareF(state[11])
+	p6_3 := g.MulF(state[6], p6_2)
+	p6_4 := g.SquareF(p6_2)
+	p7_3 := g.MulF(state[7], p7_2)
+	p7_4 := g.SquareF(p7_2)
+	p8_3 := g.MulF(state[8], p8_2)
+	p8_4 := g.SquareF(p8_2)
+	p9_3 := g.MulF(state[9], p9_2)
+	p9_4 := g.SquareF(p9_2)
+	p10_3 := g.MulF(state[10], p10_2)
+	p10_4 := g.SquareF(p10_2)
+	p11_3 := g.MulF(state[11], p11_2)
+	p11_4 := g.SquareF(p11_2)
+	state[6] = g.MulF(p6_3, p6_4)
+	state[7] = g.MulF(p7_3, p7_4)
+	state[8] = g.MulF(p8_3, p8_4)
+	state[9] = g.MulF(p9_3, p9_4)
+	state[10] = g.MulF(p10_3, p10_4)
+	state[11] = g.MulF(p11_3, p11_4)
+}
+
+func BenchmarkSboxLoop(b *testing.B) {
+	len := 10000000
+	states := make([][12]g.GoldilocksField, len)
+	for i := range states {
+		for j := 0; j < 12; j++ {
+			states[i][j] = getRandomGoldilocks()
+		}
+	}
+	id := 0
+	b.Run("Linear-Unroll-Sbox", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sbox_test1(&states[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+	id = 0
+	b.Run("Original-Sbox", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sbox_test2(&states[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+	id = 0
+	b.Run("Grouping-4-Sbox", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sbox_group3(&states[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+	id = 0
+	b.Run("Grouping-6-Sbox", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			sbox_group4(&states[id])
+			id++
+			if id == len {
+				id -= len
+			}
+		}
+	})
+}
+
+func externalLayerOriginal(s *[WIDTH]UInt128) {
+	for i := 0; i < WIDTH; i += 4 {
+		t01 := AddUInt128(s[i], s[i+1])
+		t23 := AddUInt128(s[i+2], s[i+3])
+		t0123 := AddUInt128(t01, t23)
+
+		x0 := s[i]
+		x2 := s[i+2]
+
+		s[i] = AddUInt128(AddUInt128(t0123, t01), s[i+1])
+		s[i+1] = AddUInt128(AddUInt128(AddUInt128(t0123, s[i+1]), x2), x2)
+		s[i+2] = AddUInt128(AddUInt128(t0123, t23), s[i+3])
+		s[i+3] = AddUInt128(AddUInt128(AddUInt128(t0123, s[i+3]), x0), x0)
+	}
+}
+
+func externalLayerUnrolled(s *[WIDTH]UInt128) {
+	x0, x1, x2, x3 := s[0], s[1], s[2], s[3]
+	t01 := AddUInt128(x0, x1)
+	t23 := AddUInt128(x2, x3)
+	t0123 := AddUInt128(t01, t23)
+	s[0] = AddUInt128(AddUInt128(t0123, t01), x1)
+	s[1] = AddUInt128(AddUInt128(t0123, x1), AddUInt128(x2, x2))
+	s[2] = AddUInt128(AddUInt128(t0123, t23), x3)
+	s[3] = AddUInt128(AddUInt128(t0123, x3), AddUInt128(x0, x0))
+
+	x0, x1, x2, x3 = s[4], s[5], s[6], s[7]
+	t01 = AddUInt128(x0, x1)
+	t23 = AddUInt128(x2, x3)
+	t0123 = AddUInt128(t01, t23)
+	s[4] = AddUInt128(AddUInt128(t0123, t01), x1)
+	s[5] = AddUInt128(AddUInt128(t0123, x1), AddUInt128(x2, x2))
+	s[6] = AddUInt128(AddUInt128(t0123, t23), x3)
+	s[7] = AddUInt128(AddUInt128(t0123, x3), AddUInt128(x0, x0))
+
+	x0, x1, x2, x3 = s[8], s[9], s[10], s[11]
+	t01 = AddUInt128(x0, x1)
+	t23 = AddUInt128(x2, x3)
+	t0123 = AddUInt128(t01, t23)
+	s[8] = AddUInt128(AddUInt128(t0123, t01), x1)
+	s[9] = AddUInt128(AddUInt128(t0123, x1), AddUInt128(x2, x2))
+	s[10] = AddUInt128(AddUInt128(t0123, t23), x3)
+	s[11] = AddUInt128(AddUInt128(t0123, x3), AddUInt128(x0, x0))
+}
+
+func externalLayerParallel(s *[WIDTH]UInt128) {
+	x0, x1, x2, x3 := s[0], s[1], s[2], s[3]
+	t := AddUInt128(AddUInt128(x0, x1), AddUInt128(x2, x3))
+	s[0] = AddUInt128(AddUInt128(t, x0), AddUInt128(x1, x1))
+	s[1] = AddUInt128(AddUInt128(t, x1), AddUInt128(x2, x2))
+	s[2] = AddUInt128(AddUInt128(t, x2), AddUInt128(x3, x3))
+	s[3] = AddUInt128(AddUInt128(t, x3), AddUInt128(x0, x0))
+
+	x0, x1, x2, x3 = s[4], s[5], s[6], s[7]
+	t = AddUInt128(AddUInt128(x0, x1), AddUInt128(x2, x3))
+	s[4] = AddUInt128(AddUInt128(t, x0), AddUInt128(x1, x1))
+	s[5] = AddUInt128(AddUInt128(t, x1), AddUInt128(x2, x2))
+	s[6] = AddUInt128(AddUInt128(t, x2), AddUInt128(x3, x3))
+	s[7] = AddUInt128(AddUInt128(t, x3), AddUInt128(x0, x0))
+
+	x0, x1, x2, x3 = s[8], s[9], s[10], s[11]
+	t = AddUInt128(AddUInt128(x0, x1), AddUInt128(x2, x3))
+	s[8] = AddUInt128(AddUInt128(t, x0), AddUInt128(x1, x1))
+	s[9] = AddUInt128(AddUInt128(t, x1), AddUInt128(x2, x2))
+	s[10] = AddUInt128(AddUInt128(t, x2), AddUInt128(x3, x3))
+	s[11] = AddUInt128(AddUInt128(t, x3), AddUInt128(x0, x0))
+}
+
+func BenchmarkExternalLayer(b *testing.B) {
+	size := 10000000
+	states := make([][WIDTH]UInt128, size)
+	for i := range states {
+		for j := 0; j < WIDTH; j++ {
+			states[i][j] = UInt128{Lo: uint64(getRandomGoldilocks()), Hi: uint64(getRandomGoldilocks())}
+		}
+	}
+
+	id := 0
+	b.Run("Original-ExternalLayer", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			externalLayerOriginal(&states[id])
+			id++
+			if id == size {
+				id -= size
+			}
+		}
+	})
+
+	b.Run("Unrolled-ExternalLayer", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			externalLayerUnrolled(&states[id])
+			id++
+			if id == size {
+				id -= size
+			}
+		}
+	})
+
+	b.Run("Parallel-ExternalLayer", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			externalLayerParallel(&states[id])
+			id++
+			if id == size {
+				id -= size
+			}
+		}
+	})
 }

--- a/hash/poseidon2_goldilocks_plonky2/poseidon2_test.go
+++ b/hash/poseidon2_goldilocks_plonky2/poseidon2_test.go
@@ -2,9 +2,10 @@ package poseidon2_plonky2
 
 import (
 	"bytes"
+	"crypto/rand"
 	"math"
+	"math/big"
 	"math/bits"
-	"math/rand/v2"
 	"testing"
 
 	g "github.com/elliottech/poseidon_crypto/field/goldilocks"
@@ -12,7 +13,9 @@ import (
 )
 
 func getRandomGoldilocks() g.GoldilocksField {
-	return g.GoldilocksField(rand.Uint64())
+	mx := new(big.Int).SetUint64(0xFFFFFFFF00000000) // ORDER - 1
+	a, _ := rand.Int(rand.Reader, mx)
+	return g.GoldilocksField(a.Uint64())
 }
 
 func TestPermute(t *testing.T) {

--- a/int/uint128.go
+++ b/int/uint128.go
@@ -21,27 +21,18 @@ func UInt128FromUint64(v uint64) UInt128 {
 }
 
 func AddUInt128(x, y UInt128) UInt128 {
-	var carry uint64
-	var z UInt128
-	z.Lo, carry = bits.Add64(x.Lo, y.Lo, 0)
-	z.Hi = x.Hi + y.Hi + carry
-	return z
+	sum, carry := bits.Add64(x.Lo, y.Lo, 0)
+	return UInt128{Hi: x.Hi + y.Hi + carry, Lo: sum}
 }
 
 func AddUint128AndUint64(x UInt128, y uint64) UInt128 {
-	var carry uint64
-	var v UInt128
-	v.Lo, carry = bits.Add64(x.Lo, y, 0)
-	v.Hi = x.Hi + carry
-	return v
+	sum, carry := bits.Add64(x.Lo, y, 0)
+	return UInt128{Hi: x.Hi + carry, Lo: sum}
 }
 
 func SubUint128AndUint64(x UInt128, y uint64) UInt128 {
-	var borrowed uint64
-	var v UInt128
-	v.Lo, borrowed = bits.Sub64(x.Lo, y, 0)
-	v.Hi = x.Hi - borrowed
-	return v
+	res, borrowed := bits.Sub64(x.Lo, y, 0)
+	return UInt128{Hi: x.Hi - borrowed, Lo: res}
 }
 
 func MulUInt64(x, y uint64) UInt128 {
@@ -50,11 +41,8 @@ func MulUInt64(x, y uint64) UInt128 {
 }
 
 func AddUint64(x, y uint64) UInt128 {
-	var carry uint64
-	var v UInt128
-	v.Lo, carry = bits.Add64(x, y, 0)
-	v.Hi = carry
-	return v
+	sum, carry := bits.Add64(x, y, 0)
+	return UInt128{Hi: carry, Lo: sum}
 }
 
 func MulUint128AndUint64(u UInt128, n uint64) (dest UInt128) {


### PR DESCRIPTION
Speed + memory optimizations.

Speed:
---
- Removed `branchHint`s as they aren't working.
- Manually inlined MulAccF.
- Some changes to `externalLayer` function (reordering of calculations, manual inlining).

Memory:
---
- Created `HashNToMNoPadBytesOptimized`. This new function assumes a 32-byte output array as parameter.
- Similarly updated `Sum` function.
- Directly used `bits.LittleEndian.PutUint64` function to avoid `make()` inside `ToLittleEndianBytes`.


- Added tests.
- Simple changes in `uint128` for simplicity.